### PR TITLE
cacheFactory support added

### DIFF
--- a/src/client/types/client-options.ts
+++ b/src/client/types/client-options.ts
@@ -1,4 +1,5 @@
 import { CompressionMethod, DeviceOS, InputMode } from "@serenityjs/protocol";
+import type { CacheFactory } from "prismarine-auth";
 import type { SkinData } from "./payload";
 
 type LoginPacketOptions = {
@@ -31,8 +32,8 @@ export type ClientOptions = {
 	username: string;
 	/** Whether to use a worker(for Raknet) or not. */
 	worker: boolean;
-	/** Location of the tokens folder. */
-	tokensFolder: string;
+	/** Location of the tokens folder or a cache factory function for prismarine-auth. */
+	tokensFolder: string | CacheFactory;
 	/** Skin Data for custom skins (By default we parse it from json)*/
 	skinData: SkinData | undefined;
 	/** Path to PNG skin file (alternative to skinData) */

--- a/src/shared/auth/authentication.ts
+++ b/src/shared/auth/authentication.ts
@@ -115,11 +115,6 @@ export async function authenticateWithCredentials(
 	options: AuthOptions,
 ): Promise<BedrockTokens> {
 	const { email, password, clientPublicKey, cacheDir, proxy } = options;
-
-	//cacheDir is always string (default "tokens" or cache factory)
-	//if string use FileCache factory otherwise use passed cache factory
-	
-
 	const proxiedFetch = createProxiedFetch(proxy);
 
 	// Verify proxy is working by checking our IP

--- a/src/shared/cache/Filecache.ts
+++ b/src/shared/cache/Filecache.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { Cache } from 'prismarine-auth'  
 
 //prismarine-auth uses 'any' instead of 'Record<string, unknown>' but fails linting
@@ -13,6 +14,10 @@ export class FileCache implements Cache {
 
   async reset(): Promise<void> {
     this.cache = {}
+    const dir = path.dirname(this.cacheLocation)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
   }
 
@@ -34,6 +39,10 @@ export class FileCache implements Cache {
 
   async setCached(cached: Record<string, unknown>): Promise<void> {
     this.cache = cached
+    const dir = path.dirname(this.cacheLocation)
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
     fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
   }
 

--- a/src/shared/cache/Filecache.ts
+++ b/src/shared/cache/Filecache.ts
@@ -1,0 +1,46 @@
+import * as fs from "node:fs";
+import type { Cache } from 'prismarine-auth'  
+
+//prismarine-auth uses 'any' instead of 'Record<string, unknown>' but fails linting
+
+export class FileCache implements Cache {
+  private cacheLocation: string
+  private cache?: Record<string, unknown>
+
+  constructor(cacheLocation: string) {
+    this.cacheLocation = cacheLocation
+  }
+
+  async reset(): Promise<void> {
+    this.cache = {}
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+  }
+
+  private async loadInitialValue(): Promise<Record<string, unknown>> {
+    try {
+      return JSON.parse(fs.readFileSync(this.cacheLocation, 'utf8')) as Record<string, unknown>
+    } catch {
+      await this.reset()
+      return {}
+    }
+  }
+
+  async getCached(): Promise<Record<string, unknown>> {
+    if (this.cache === undefined) {
+      this.cache = await this.loadInitialValue()
+    }
+    return this.cache
+  }
+
+  async setCached(cached: Record<string, unknown>): Promise<void> {
+    this.cache = cached
+    fs.writeFileSync(this.cacheLocation, JSON.stringify(this.cache))
+  }
+
+  async setCachedPartial(cached: Record<string, unknown>): Promise<void> {
+    await this.setCached({
+      ...this.cache,
+      ...cached
+    })
+  }
+}


### PR DESCRIPTION
Uses the same cacheFactory which prismarine-auth uses to make it compatible. Credential auth still uses the same hashing. Default tokensFolder still used of '/tokens'.

Potentially change tokensFolder to cacheDir for consistency?